### PR TITLE
Make ENU and NED coordinate frames consistent

### DIFF
--- a/ros/src/airsim_car_ros_pkgs/launch/airsim_node.launch
+++ b/ros/src/airsim_car_ros_pkgs/launch/airsim_node.launch
@@ -10,6 +10,9 @@
 		<param name="update_airsim_control_every_n_sec" type="double" value="0.02" />
 		<param name="update_lidar_every_n_sec" type="double" value="0.05" />
 
-		<remap from="/airsim_node/PhysXCar/odom_local_ned" to="/odom"/>
-	</node>
+		<remap from="/airsim_node/PhysXCar/odom_local_enu" to="/odom"/>
+  </node>
+
+  <node pkg="tf" type="static_transform_publisher" name="ned_to_enu_pub" args="0 0 0 1.57 0 3.14 world_ned world_enu 100"/>
+
 </launch>


### PR DESCRIPTION
* Connect disconnected TF trees
* Make ENU/NED coordinates consistent
* Consolidate to a single LIDAR due to AirSim constraints
* Place camera frames correctly

Signed-off-by: P. J. Reed <preed@swri.org>